### PR TITLE
Jobinfo

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/acquirecloud/golibs v0.3.6 h1:XOugmfqXhZRpsyUHge1NEjaHEyeS0agdPlLX5w2PPsI=
-github.com/acquirecloud/golibs v0.3.6/go.mod h1:s/t1NzhURZuxbb+2SzglqfBUqprUZljsxgF/4s6mKBE=
-github.com/acquirecloud/golibs v0.3.7 h1:x6uM7o1bNiKJVhkcQc5wzeEQZp/mUBKszeNqBLjKXSQ=
-github.com/acquirecloud/golibs v0.3.7/go.mod h1:s/t1NzhURZuxbb+2SzglqfBUqprUZljsxgF/4s6mKBE=
 github.com/acquirecloud/golibs v0.3.8 h1:QXudivK5KbPmZCfTN7ocbtbtcK3+tdCrr+VHfwTTa0A=
 github.com/acquirecloud/golibs v0.3.8/go.mod h1:s/t1NzhURZuxbb+2SzglqfBUqprUZljsxgF/4s6mKBE=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZpUGpz5+4FfNmIU+FmZg2P3Xaj2v2bfNWmk=

--- a/kafkaq.go
+++ b/kafkaq.go
@@ -25,8 +25,8 @@ type (
 
 	// Job is an object that allows to signal the task completion.
 	Job interface {
-		// Info returns the JobInfo object for the job
-		Info() JobInfo
+		// ID returns the Job ID
+		ID() string
 
 		// Task returns the task for the job.
 		Task() Task

--- a/kafkaq.go
+++ b/kafkaq.go
@@ -15,6 +15,7 @@ package kafkaq
 
 import (
 	"context"
+	"time"
 )
 
 type (
@@ -24,6 +25,9 @@ type (
 
 	// Job is an object that allows to signal the task completion.
 	Job interface {
+		// Info returns the JobInfo object for the job
+		Info() JobInfo
+
 		// Task returns the task for the job.
 		Task() Task
 
@@ -36,11 +40,27 @@ type (
 		Done() error
 	}
 
+	// JobController allows to discover information about jobs in the queue
+	JobController interface {
+		// Get returns the JobInfo for the job ID provided. The function returns
+		// error if the JobInfo may not be obtained for whatever reasons, otherwise
+		// it will return the job status and some information about it
+		Get(jid string) (JobInfo, error)
+
+		// Cancel allows to stop the future job processing by its id. If the job is
+		// not returned for processing yet, it will be not, after the call. If the
+		// job was already done, nothing will happen. The call may be made
+		// in the middle of the job processing, and it will not interrupt it, but it
+		// will affect only further job runs if they are scheduled.
+		Cancel(jid string) (JobInfo, error)
+	}
+
 	// TaskPublisher allows to submit a new task into the queue. It separated from the
 	// Queue object cause not all publishers need to consume jobs from the queue.
 	TaskPublisher interface {
-		// Publish places the Task into the queue
-		Publish(Task) error
+		// Publish places the Task into the queue. The function returns the
+		// new Job ID for the task which will be returned by Queue.GetJob() later
+		Publish(Task) (string, error)
 	}
 
 	// Queue interface represents the queue object: Tasks may be published to the queue
@@ -55,4 +75,38 @@ type (
 		// if the task can be retrieved (normally if the ctx is closed)
 		GetJob(ctx context.Context) (Job, error)
 	}
+
+	// JobStatus contains the status of a job, please see constants below
+	JobStatus int
+
+	// JobInfo contains information about a job
+	JobInfo struct {
+		// ID contains the Job ID
+		ID string
+		// Status contains the known status for the job
+		Status JobStatus
+		// Rescedules contains how many times the job was returned by the rescheduling timeout
+		Rescedules int
+		// NextExecutionAt contains the timestamp when the job will be executed if it will
+		// not be done before it.
+		NextExecutionAt time.Time
+	}
+)
+
+const (
+	// JobStatusUnknown indicates that the job is not seen yet, or it was
+	// done some time ago, so the information about the job is already gone. The
+	// State indicates there is no record about the job, it is not quite possible to say
+	// whether the job ever existed or not seen yet.
+	JobStatusUnknown JobStatus = iota
+
+	// JobStatusProcessing indicates that the job is seen, distributed and not done yet.
+	// This state indicates that the job was selected, but it is not done (for whatever reasons)
+	// yet. The job can be rescheduled and returned for the next run. The information about when
+	// the Job can be run again maybe found in the JobInfo object.
+	JobStatusProcessing
+
+	// JobStatusDone indicates that the job existed, it is done, and the record about it still exists
+	// in the queue.
+	JobStatusDone
 )


### PR DESCRIPTION
The PR adds JobInfo.  The information may seem weird, but this is the correct information for the implementation. 
Rationale:
- there are no such things as the job is running now. What we can conclude is only the info on the task was scheduled, and it is sent to the consumer. We don't know much about what is going on, but whether it is distributed or done. We can't say how many are in the process now. We can say how many times the job was rescheduled and distributed. 

Please consider. 